### PR TITLE
Add `url` to `_config.yml` to fix RSS feed permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: byroot's blog
 description: >- # this means to ignore newlines until "baseurl:"
   Various ramblings.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://byroot.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: _byroot
 bluesky_username: byroot
 github_username:  byroot


### PR DESCRIPTION
I haven't been able to click from my RSS feed reader to the article hosted online because the feed URL is showing up as something like

```
/ruby/json/2024/12/27/optimizing-ruby-json-part-3.html
```

instead of

```
https://byroot.github.io/ruby/json/2024/12/27/optimizing-ruby-json-part-3.html
```

so when my feed reader attempts to open the URL, there's no protocol nor hostname, and opening the link fails.