### PR TITLE
fix: typo in socket example

### DIFF
--- a/_posts/2025-03-21-database-protocols.markdown
+++ b/_posts/2025-03-21-database-protocols.markdown
@@ -80,7 +80,7 @@ Under the hood, most if not all clients will look like this:
 ```ruby
 def query(command)
   packet = serialize(command)
-  @socket.write(command)
+  @socket.write(packet)
   response = @socket.read
   deserialize(response)
 end


### PR DESCRIPTION
Serialized command is usually written to the socket.