### PR TITLE
Fix code example typo in faster-paths blog

### DIFF
--- a/_posts/2026-04-18-faster-paths.markdown
+++ b/_posts/2026-04-18-faster-paths.markdown
@@ -189,7 +189,7 @@ def scan(dir_path, requirables = [], directories = [])
   Dir.foreach(dir_path) do |name|
     path = "#{absolute_dir_path}/#{name}"
     if File.directory?(path)
-      directory << path
+      directories << path
       scan(path, requirables, directories)
     elsif name.end_with?(".rb", ".so")
       requirables << name


### PR DESCRIPTION
I'm enjoying your new article, and I noticed a typo in the code example of the directory scan.